### PR TITLE
400 Bad Request fix after using Multiple user IDs or logins

### DIFF
--- a/src/Managers/StreamManagers.ts
+++ b/src/Managers/StreamManagers.ts
@@ -58,7 +58,7 @@ class StreamManager extends EventEmitter {
               parameters?.user_login &&
               parameters.user_login.length > 0 &&
               parameters.user_login.length < 101 &&
-              parameters.user_login.map(u => `&user_login=${u}`)
+              parameters.user_login.map(u => `&user_login=${u}`).join('')
             }
         `);
 

--- a/src/Managers/StreamManagers.ts
+++ b/src/Managers/StreamManagers.ts
@@ -46,7 +46,7 @@ class StreamManager extends EventEmitter {
               parameters?.user_id &&
               parameters.user_id.length > 0 &&
               parameters.user_id.length < 101 &&
-              parameters.user_id.map(u => `&user_id=${u}`)
+              parameters.user_id.map(u => `&user_id=${u}`).join('')
             }
             ${
               parameters?.language &&


### PR DESCRIPTION
the problem is that the array is not joined to a string after adding the user_login parameter in StreamManagers.js, because if it is not done, the url remains as user_login=channel1,&user_login=channel2, incorrectly separated by commas